### PR TITLE
Made `Account` take any `V` as value instead of only taking `Box<dyn Setting>`

### DIFF
--- a/src/types/rust_types_implementations.rs
+++ b/src/types/rust_types_implementations.rs
@@ -329,15 +329,15 @@ mod tests {
     #[test]
     fn bool_stg_conversion() {
         let bool = true;
-        let stg_fun: Box<dyn Setting> = stg(bool);
-        let stg_dot: Box<dyn Setting> = bool.stg();
-        assert!(stg_fun == stg_dot.clone());
+        let stg_fun: Stg = bool.stg();
+        let stg_dot: Stg = bool.stg();
+        assert!(stg_fun == stg_dot);
         let stg_fun_1 = stg_fun.clone();
         let stg_dot_1 = stg_fun.clone();
-        let bool_dot_unstg: bool = unstg(stg_fun);
-        let bool_dot_safe_unstg: bool = *safe_unstg(stg_dot).unwrap();
-        let bool_fun_unstg: bool = unstg(stg_fun_1);
-        let bool_fun_safe_unstg: bool = *safe_unstg(stg_dot_1).unwrap();
+        let bool_dot_unstg: bool = stg_fun.unstg_panic();
+        let bool_dot_safe_unstg: bool = stg_dot.unstg().unwrap();
+        let bool_fun_unstg: bool = stg_fun_1.unstg_panic();
+        let bool_fun_safe_unstg: bool = stg_dot_1.unstg().unwrap();
         assert!(bool_dot_unstg == bool);
         assert!(bool_fun_unstg == bool);
         assert!(bool_dot_unstg == bool_dot_safe_unstg);


### PR DESCRIPTION
Made `Account` take any `V` as value instead of only taking `Box<dyn Setting>`

`removed`  `Box<dyn Setting>` specific methods from `Account`

`add` `Stg` type to substitute `Box<dyn Setting>` and made functions and methods that interacted part of it.

`add` `StgTrait` for easy interaction with `Option<&Stg>` from `.get()`

`fix` `doc`s examples, but `doc`s themselves haven't been fixed.

solves #29