### PR TITLE
`doc`: Updated Documentation (and fixed push method)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ clippy.perf = "warn"
 clippy.style = "warn"
 clippy.suspicious = "warn"
 rust.missing_docs = "warn"
+
+[unstable]
+trait_upcasting = true

--- a/README v0.5.0 .md
+++ b/README v0.5.0 .md
@@ -1,4 +1,4 @@
-# HashMapSettings [![Version]][Crates.io] [![Rust Version]][Rust 1.76] [![Documentation]][Docs.rs] [![Build Status]][Actions]
+# HashMapSettings [![Version]][Crates.io] [![Rust Version]][Nightly] [![Documentation]][Docs.rs] [![Build Status]][Actions]
 
 [Version]: https://img.shields.io/crates/v/hashmap_settings.svg
 [Crates.io]: https://crates.io/crates/hashmap_settings
@@ -6,18 +6,49 @@
 [Docs.rs]: https://docs.rs/hashmap_settings
 [Build Status]: https://img.shields.io/github/actions/workflow/status/OxidizedLoop/HashMapSettings/rust.yml
 [Actions]: https://github.com/OxidizedLoop/HashMapSettings/actions
-[Rust Version]: https://img.shields.io/badge/rust-1.76+-lightgray.svg
-[Rust 1.76]: https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html
+[Rust Version]: https://img.shields.io/badge/rust-nightly-lightgray.svg
+[Nightly]: https://github.com/rust-lang/rust/issues/65991
 
-## **A HashMap wrapper for layered Settings of distinct types**
+## `HashMap` wrapper for layered settings
 
-This crate allows a developer to store and access all program settings on a `Account` struct, a wrapper around a `HashMap` that can hold any type that implements `Setting`.
+This crate facilitates the management of settings, with the goal of allowing developers to turn previously needlessly set in stone
+values into a setting a user can change, as well as making it easier for a developer to create multiple priority levels of settings,
+allowing users to have greater control and customization including across devices.
 
-An `Account` can also hold other Accounts, allowing the existence of layered settings.
+This crate allows a developer to store and access all program settings on a `Account`,
+a wrapper around a `HashMap`.
 
-This makes it possible to create complex systems where multiple places (eg: Themes, Extensions, Global User Settings, Local User Settings) are changing the same settings, and the value is taken from the top layer containing the setting or the default layer if no other layer contained it.
+This crate is intended to be used with some sort of type abstraction so that settings of distinct types can be stored in
+a single `Account`. This crate provides the `Stg` type abstraction for this.
+
+An `Account` can also hold other Accounts, allowing the existence of layered settings,
+that permit the creation complex systems that have the:
+
+### Benefits
+
+1. Having multiple places changing the same setting with the value being taken from the place that is deemed
+to have the most importance.
+(eg: Default, Themes, Extensions, Global Settings, OS Settings, Device Settings, Temporary Settings )
+
+2. Organization of Settings. Given that an `Account` can hold accounts, and they can hold accounts of they own, its possible for
+small groups of settings to be organized in an `Account`, making it more convenient to locate a setting, or display a group of settings.
+Important to notice that this organization doesn't need to be (but could be) enforced in all held accounts equally.
+
+3. `Account`s can be individually deactivated allowing for a developer (or a user)
+to group settings in an `Account` and easily ignore them under certain conditions.
+
+### Drawbacks
+
+1. Each `Account` holds a copy of the settings present in it's child Accounts, so there is a memory cost, but its
+[planned](https://github.com/OxidizedLoop/HashMapSettings/issues/28) for it to be changed to a reference to the value instead.
+
+2. Having to internally do a `HashMap`'s .get() will most likely be slower than alternatives.
 
 ## How to use
+
+This crate relies on the nightly feature [dyn trait upcasting](https://github.com/rust-lang/rust/issues/65991)
+that was supposed to be stable in rust 1.76.0, unfortunately it has been [delayed](https://github.com/rust-lang/rust/pull/120233)
+so currently the nightly compiler is required.
 
 Add the following line to your Cargo.toml:
 
@@ -29,34 +60,8 @@ hashmap_settings = "0.5"
 Add the following line to your .rs file:
 
 ```rust
-use hashmap_settings::{Account,Setting};
-```
-
-In the [future](https://github.com/OxidizedLoop/HashMapSettings/issues/1) you will be able to derive Setting, but for now you can implement it by adding the following lines:
-
-```rust
-#[typetag::serde] //if serde feature is activated
-impl Setting for MyType {}
-```
-
-Basic use of an `Account`:
-
-```rust
-//creating a basic account
-let mut account = Account::<(),&str>::default();
-
-//inserting values of distinct types
-account.insert("Number of trees",5);
-account.insert("Grass color","green".to_string());
-account.insert("Today is good",true);
-
-//getting values from the account 
-let today_bool: bool = account.get("Today is good").unwrap();
-let grass_color: String = account.get("Grass color").unwrap();
-let trees: i32 = account.get("Number of trees").unwrap();
-
-//example of using the values 
-print!("It's {today_bool} that today is a wonderful day, the grass is {grass_color} and I can see {trees} trees in the distance");
+# #[allow(warnings)]
+use hashmap_settings::account::Account;
 ```
 
 ## License

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1637,10 +1637,6 @@ impl<
     /// );
     /// ```
     pub fn push(&mut self, account: Self, valid: Valid) {
-        if self.valid.names && valid.names && self.accounts_names().contains(&&account.name) {
-            //todo! change account name thingy
-            self.fix_valid(Valid::new(true, false, false));
-        }
         if self.valid.children && valid.children && !account.valid.is_valid() {
             self.fix_valid(Valid::new(false, false, true));
         }
@@ -1652,7 +1648,12 @@ impl<
                 self.insert(setting.to_owned(), account.get(setting).unwrap().clone());
             }
         }
-        self.accounts.push(account);
+        if self.valid.names && valid.names && self.accounts_names().contains(&&account.name) {
+            self.accounts.push(account);
+            self.fix_valid(Valid::new(true, false, false));
+        } else {
+            self.accounts.push(account);
+        }
     }
     /// Appends an `Account` to the back of the `Vec` of child `Accounts` of a child `Account`.
     ///

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -103,9 +103,15 @@ use crate::stg::Setting;
 ///
 ///  - [`capacity`](Account::capacity): Returns the number of elements the map can hold without reallocating.
 ///
-///  - [`update_setting`](Account::update_setting): todo!(add other update details).
+///  - [`update_setting`](Account::update_setting): Updates a setting with the value its supposed to have.
 ///
+///  - [`update_setting`](Account::update_setting_returns): Updates a setting with the value its supposed to have and.
+/// 
+///  - [`update_setting`](Account::update_vec): Updates a group of settings with the value they are supposed to have.
+/// 
+///  - [`update_setting`](Account::update_all_settings): Updates all settings currently present in the Account with the value they are supposed to have.
 ///
+/// 
 /// # [Accounts](Account#accounts)
 ///
 ///
@@ -137,6 +143,7 @@ use crate::stg::Setting;
 ///
 /// # [Valid](Account#valid)
 ///  
+/// 
 /// A valid `Account` is one where it's methods will always behave as intended.
 ///
 /// There are certain methods that may make an Account invalid if improperly used,

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,4 +1,3 @@
-
 ///module including `Incrementable` implementations activated by the default feature "incrementable"
 #[cfg(feature = "incrementable")]
 pub mod incrementable_implementations;
@@ -106,22 +105,22 @@ use crate::stg::Setting;
 ///  - [`update_setting`](Account::update_setting): Updates a setting with the value its supposed to have.
 ///
 ///  - [`update_setting`](Account::update_setting_returns): Updates a setting with the value its supposed to have and.
-/// 
+///
 ///  - [`update_setting`](Account::update_vec): Updates a group of settings with the value they are supposed to have.
-/// 
+///
 ///  - [`update_setting`](Account::update_all_settings): Updates all settings currently present in the Account with the value they are supposed to have.
 ///
-/// 
+///
 /// # [Accounts](Account#accounts)
 ///
 ///
 /// A `Vec` of Accounts. The Account that holds the `Vec` is the parent Account and the Accounts that are being held
 /// are the child Accounts.
 ///
-/// The consider the bottom layer of the `Vec` Account at index 0, and the top layer the on at len()-1.
+/// We consider the bottom layer of the `Vec` the Account at index 0, and the top layer the on at len()-1.
 ///
 /// When the `Vec` is changed, the parent account will update its settings, such that when
-/// we use [get](Account.get) on the parent Account we obtain the value from the top layer
+/// we use [get()](Account::get) on the parent Account we obtain the value present in the top layer
 /// containing the setting or return `None` if no layer contained it.
 ///
 ///  - [`accounts`](Account::accounts): Get an Account's child `Accounts`
@@ -143,7 +142,7 @@ use crate::stg::Setting;
 ///
 /// # [Valid](Account#valid)
 ///  
-/// 
+///
 /// A valid `Account` is one where it's methods will always behave as intended.
 ///
 /// There are certain methods that may make an Account invalid if improperly used,
@@ -159,17 +158,21 @@ use crate::stg::Setting;
 ///
 /// `Valid` contains 3 `bool` fields corresponding to the 3 ways an account can be invalid:
 ///
-/// names: An `Account` is invalid if it's children `Accounts` have duplicated names.
+/// - names: An `Account` is invalid if it's children `Accounts` have duplicated names.
 ///
-/// settings: An `Account` is invalid if it doesn't contain all settings present in it's children `Accounts`.
+/// - settings: An `Account` is invalid if it doesn't contain all settings present in it's children `Accounts`.
 ///
-/// accounts: An `Account` is invalid if it's children `Accounts` are themselves invalid.
+/// - accounts: An `Account` is invalid if it's children `Accounts` are themselves invalid.
 ///
 /// If all the fields are true then the `Account` is valid.
 ///
-/// An Account can be temporary made invalid  for either efficiency (using [push](Account::push) or [pop](Account::pop) repeatedly) 
-/// or while using [deep_mut](Account::deep_mut) for something that isn't covered by the other [deep functions](Account#deep-functions).
-/// But this should be fixed by 
+/// An Account can be temporary made invalid for:
+///
+///  - efficiency (eg: using [push](Account::push) or [pop](Account::pop) repeatedly)
+///
+///  - using [deep_mut](Account::deep_mut) for something that isn't covered by the other [deep functions](Account#deep-functions).
+///
+/// But this should be fixed immediately after. 
 ///
 /// -[valid](Account::valid): Returns a reference to the `Account` `valid` field.
 ///
@@ -1834,7 +1837,7 @@ impl<
     > Setting for Account<N, K, V>
 {
     fn typetag_deserialize(&self) {
-        //todo!(figure what this is supposed to do as its not mut, and return "()")
+        //todo!(figure what this is supposed to do as its not mut, and returns "()")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //! use hashmap_settings::account::Account;
 //! ```
 
+#![feature(trait_upcasting)]
+
 #![doc(test(attr(deny(warnings))))] //no warnings in tests
 /// module containing [`Account`]
 pub mod account;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,49 @@
-//! `HashMap` wrapper for layered Settings of distinct types.
+//! ## `HashMap` wrapper for layered settings
 //!
-//! This crate allows a developer to store and access all program settings on a [`Account`](crate::account::Account) struct,
-//! a wrapper around a [`HashMap`](std::collections::HashMap) that can hold any type that implements [`Setting`](crate::setting::Setting).
-//!```
-//!# use hashmap_settings::stg::Setting;
-//!# //use serde::{Deserialize, Serialize};
-//!# #[derive(Clone, Debug, PartialEq)] //, Deserialize, Serialize
-//!# pub struct MyType{}
-//! // add #[typetag::serde] if serde feature is activated
-//!impl Setting for MyType{}
-//! ```
-//!  
-//! An Account can also hold other [Accounts](crate::account::Account#accounts), allowing the existence of layered settings.
+//! This crate facilitates the management of settings, with the goal of allowing developers to turn previously needlessly set in stone
+//! values into a setting a user can change, as well as making it easier for a developer to create multiple priority levels of settings,
+//! allowing users to have greater control and customization including across devices.
 //!
-//! This makes it possible to create complex systems where multiple places
-//! (eg: Themes, Extensions, Global User Settings, Local User Settings)
-//! are changing the same settings, and the value is taken from the top layer containing the setting
-//! or the default layer if no other layer contained it.
+//! This crate allows a developer to store and access all program settings on a [`Account`](crate::account::Account),
+//! a wrapper around a [`HashMap`](std::collections::HashMap).
 //!
-//! This crate gives the tools necessary for a developer to create layered settings.
-//! This allows users of the application to not only have different settings for different environments,
-//! but also have groups of settings that they can easily swap.
+//! This crate is intended to be used with some sort of type abstraction so that settings of distinct types can be stored in
+//! a single `Account`. This crate provides the [`Stg`](crate::stg::Stg) type abstraction for this.
+//!
+//! An `Account` can also hold other [Accounts](crate::account::Account#accounts), allowing the existence of layered settings,
+//! that permit the creation complex systems that have the:
+//!
+//! ### Benefits
+//!
+//! 1. Having multiple places changing the same setting with the value being taken from the place that is deemed
+//! to have the most importance.
+//! (eg: Default, Themes, Extensions, Global Settings, OS Settings, Device Settings, Temporary Settings )
+//!
+//! 2. Organization of Settings. Given that an `Account` can hold accounts, and they can hold accounts of they own, its possible for
+//! small groups of settings to be organized in an `Account`, making it more convenient to locate a setting, or display a group of settings.
+//! Important to notice that this organization doesn't need to be (but could be) enforced in all held accounts equally.
+//!
+//! 3. `Account`s can be individually [deactivated](crate::account::Account#active) allowing for a developer (or a user)
+//! to group settings in an `Account` and easily ignore them under certain conditions.
+//!
+//! ### Drawbacks
+//!
+//! 1. Each `Account` holds a copy of the settings present in it's child Accounts, so there is a memory cost, but its
+//! [planned](https://github.com/OxidizedLoop/HashMapSettings/issues/28) for it to be changed to a reference to the value instead.
+//!
+//! 2. Having to internally do a [`HashMap`](std::collections::HashMap)'s .get() will most likely be slower than alternatives.
 //!
 //! ## How to use
+//!
+//! This crate relies on the nightly feature [dyn trait upcasting](https://github.com/rust-lang/rust/issues/65991)
+//! that was supposed to be stable in rust 1.76.0, unfortunately it has been [delayed](https://github.com/rust-lang/rust/pull/120233)
+//! so currently the nightly compiler is required.
 //!
 //! Add the following line to your Cargo.toml:
 //!
 //! ```toml
 //! [dependencies]
-//! hashmap_settings = "0.4"
+//! hashmap_settings = "0.5"
 //! ```
 //!
 //! Add the following line to your .rs file:
@@ -37,35 +52,11 @@
 //! # #[allow(warnings)]
 //! use hashmap_settings::account::Account;
 //! ```
-//!
-//! Basic use of an `Account` without layers:
-//!
-//! ```rust
-//! /*
-//! # use hashmap_settings::account::Account;
-//! //creating a basic account
-//! let mut account = Account::<(),&str>::default();
-//!
-//! //inserting values of distinct types
-//! account.insert("Number of trees",5);
-//! account.insert("Grass color","green".to_string());
-//! account.insert("Today is good",true);
-//!
-//! //getting values from the account
-//! let today_bool: bool = account.get(&"Today is good").unwrap();
-//! let grass_color: String = account.get(&"Grass color").unwrap();
-//! let trees: i32 = account.get(&"Number of trees").unwrap();
-//!
-//! //example of using the values
-//! print!("It's {today_bool} that today is a wonderful day,
-//!     the grass is {grass_color} and I can see {trees} trees in the distance");
-//! */
-//! ```
 
 #![doc(test(attr(deny(warnings))))] //no warnings in tests
-///module containing `Account`
+/// module containing [`Account`]
 pub mod account;
-///module containing the Stg type
+/// module containing the type abstraction [`Stg`]
 pub mod stg;
 
 #[cfg(test)]
@@ -74,7 +65,7 @@ mod tests {
 
     use crate::{
         account::Account,
-        stg::{Setting, Stg, StgTrait,StgError},
+        stg::{Setting, Stg, StgError, StgTrait},
     };
 
     #[test]

--- a/src/stg/mod.rs
+++ b/src/stg/mod.rs
@@ -59,13 +59,19 @@ impl PartialEq for Box<dyn Setting> {
 /// Types implementing `Setting` can be turned into a `Stg` with [.stg()](Setting::stg).
 ///
 /// ```
-/// //todo!(example)
+/// use hashmap_settings::stg::{Setting,Stg};
+/// # #[allow(unused_variables)]
+/// let bool_stg: Stg = true.stg();
 /// ```
 ///
 /// They can be turned back to a specific type with [.unstg()](Stg::unstg) or [.unstg_panic()](Stg::unstg_panic)
 ///
 ///  ```
-/// //todo!(example)
+/// # use hashmap_settings::stg::{Setting,Stg};
+/// # let bool_stg: Stg = true.stg();
+/// # #[allow(unused_variables)]
+/// let bool: bool = bool_stg.unstg()?;
+/// # Ok::<(),Box<dyn core::any::Any>>(())
 /// ```
 ///
 /// Additionally there is the [`StgTrait`] that can be implemented for types containing `Stg` to allow
@@ -74,7 +80,14 @@ impl PartialEq for Box<dyn Setting> {
 /// The main example would be [Option<&Stg>]
 ///
 ///  ```
-/// //todo!(example)
+/// use std::collections::HashMap;
+/// use hashmap_settings::stg::{Setting,Stg,StgError,StgTrait};
+/// let bool_stg: Stg = true.stg();
+/// let mut hashmap = HashMap::new();
+/// hashmap.insert("bool",bool_stg);
+/// # #[allow(unused_variables)]
+/// let bool: bool = hashmap.get("bool").unstg()?;
+/// # Ok::<(),StgError>(())
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
@@ -184,7 +197,7 @@ impl StgTrait for Option<&Stg> {
         self.map_or(Err(StgError::None), |value| {
             match value.clone().unstg::<S>() {
                 Ok(value) => Ok(value),
-                Err(_error) => Err(StgError::WrongType), //todo! change WrongType to contain error Err(StgError::WrongType(error)),
+                Err(_error) => Err(StgError::WrongType),
             }
         })
     }
@@ -282,6 +295,6 @@ pub trait StgTrait {
 pub enum StgError {
     /// No value found, equivalent to None in Option()
     None,
-    /// Error of trying to  convert to the wrong type, todo!()Err(Box<dyn Any>), result from calling the if we try to covert to the wrong type
-    WrongType,
+    /// Error of trying to convert to the wrong type,
+    WrongType, //todo!() change WrongType to contain the error Err(StgError::WrongType(Box<dyn core::any::Any>)),
 }

--- a/src/stg/mod.rs
+++ b/src/stg/mod.rs
@@ -1,3 +1,38 @@
+//! This module contains the type abstraction [`Stg`] and other relevant elements.
+//! 
+//! [`Stg`] type abstraction  
+//! 
+//! [`Setting`] is the trait that needs to be implemented for types for them to be turned into `Stg`
+//! 
+//! [`StgError`] Error on conversion from `Stg` or T<&Stg> into S: Setting
+//! 
+//! [`StgTrait`] Trait implement 
+//! 
+//! 
+//! # Example use of `Stg` without layers but with distinct types:
+//!
+//! ```rust
+//! use hashmap_settings::{account::Account,stg::{Setting,Stg,StgTrait,StgError}};
+//! //creating an account
+//! let mut account = Account::<(),&str,Stg>::default();
+//!
+//! //inserting values of distinct types
+//! account.insert("Number of trees",5.stg());
+//! account.insert("Grass color","green".to_string().stg());
+//! account.insert("Today is good",true.stg());
+//!
+//! //getting values from the account
+//! let today_bool: bool = account.get(&"Today is good").unstg()?;
+//! let grass_color: String = account.get(&"Grass color").unstg()?;
+//! let trees: i32 = account.get(&"Number of trees").unstg()?;
+//!
+//! //example of using the values
+//! print!("It's {today_bool} that today is a wonderful day,
+//!     the grass is {grass_color} and I can see {trees} trees in the distance");
+//! 
+//! Ok::<(),StgError>(())
+//! ```
+
 ///module containing implementations of `Setting` for rust types
 pub mod setting_implementations;
 

--- a/src/stg/mod.rs
+++ b/src/stg/mod.rs
@@ -1,14 +1,14 @@
 //! This module contains the type abstraction [`Stg`] and other relevant elements.
-//! 
+//!
 //! [`Stg`] type abstraction  
-//! 
+//!
 //! [`Setting`] is the trait that needs to be implemented for types for them to be turned into `Stg`
-//! 
+//!
 //! [`StgError`] Error on conversion from `Stg` or T<&Stg> into S: Setting
-//! 
-//! [`StgTrait`] Trait implement 
-//! 
-//! 
+//!
+//! [`StgTrait`] Trait implement
+//!
+//!
 //! # Example use of `Stg` without layers but with distinct types:
 //!
 //! ```rust
@@ -29,7 +29,7 @@
 //! //example of using the values
 //! print!("It's {today_bool} that today is a wonderful day,
 //!     the grass is {grass_color} and I can see {trees} trees in the distance");
-//! 
+//!
 //! Ok::<(),StgError>(())
 //! ```
 
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 /// # #[derive(Clone, Debug, PartialEq)] //, Deserialize, Serialize
 /// # pub struct MyType{}
 /// // add #[typetag::serde] if serde feature is activated
-///impl Setting for MyType{}
+/// impl Setting for MyType{}
 /// ```
 #[cfg_attr(feature = "serde", typetag::serde(tag = "setting"))]
 pub trait Setting: Any + Debug + DynClone + DynEq {


### PR DESCRIPTION
`doc`: Updated Documentation, 


also fixed Account .push() to correctly fix names